### PR TITLE
add `auto-close` ability to `dropdown.js`

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -41,6 +41,17 @@
       var $this         = $(this)
       var $parent       = getParent($this)
       var relatedTarget = { relatedTarget: this }
+      var autoClose = $this.attr('data-auto-close')
+
+      if (e && e.type == 'click') {
+        var isMenuTarget = $.contains($parent[0], e.target);
+        if (
+          (autoClose === 'inside' && !isMenuTarget) ||
+          (autoClose === 'outside' && isMenuTarget)
+        ) {
+          return
+        }
+      }
 
       if (!$parent.hasClass('open')) return
 


### PR DESCRIPTION
### Problem
Bootstrap dropdown menus close automatically when clicking inside the menu. We have "settings" menus where we don't want this to happen, so we were hacking in "stopPropagation" in the elements which is not ideal. 

### Solution
Implemented an argument to allow for closing the menu only when clicking "outside" of it.

- data-auto-close="inside" - closes when a user clicks inside the menu
- data-auto-close="outside" - closes when a user clicks anywhere outside the menu

Roughly based off [Bootstrap 5](https://getbootstrap.com/docs/5.0/components/dropdowns/#options), however didn't spend too much time implementing all the options.